### PR TITLE
use next instead of ⬇

### DIFF
--- a/_includes/section2.html
+++ b/_includes/section2.html
@@ -1,7 +1,7 @@
 <section id="section2" class="flex-it">
   <div class="section2-image"></div>
   <p class="text">Hi! I’m Anna. My friend John and I just arrived in Ghent and we’re in quite a hurry to find a parking spot!</p>
-  <a href="#section3" id="to-section3" class="internal-link internal-arrow">⬇</a>
+  <a href="#section3" id="to-section3" class="internal-link internal-arrow">next</a>
   <script>
     document.getElementById('to-section3').addEventListener('click',function(){
       var styled = document.querySelectorAll('#iconGhent, #textGhent, #iconCross');

--- a/_includes/section3.html
+++ b/_includes/section3.html
@@ -10,5 +10,5 @@
     <p>On my phone, I can install apps which show me information about parking sites in for instance Brussels and Ghent</p>
     <p id="textGhent">But the parking app for Ghent doesn’t work on my phone</p>
   </div>
-  <a href="#section4" class="internal-link internal-arrow">⬇</a>
+  <a href="#section4" class="internal-link internal-arrow">next</a>
 </section>

--- a/_includes/section4.html
+++ b/_includes/section4.html
@@ -24,5 +24,5 @@
   <div class="text text-flex-basis-60 full-basis-text">
     <p>John has apps for all cities he frequently visits but they clutter his phone</p>
   </div>
-  <a href="#section5" class="internal-link internal-arrow">⬇</a>
+  <a href="#section5" class="internal-link internal-arrow">next</a>
 </section>

--- a/_includes/section5.html
+++ b/_includes/section5.html
@@ -3,5 +3,5 @@
     <img src="{{site.baseurl}}/src/img/anna_perfectappworld.svg" alt="">
   </div>
   <p class="text">Wouldn't it be great if developers could include more data in their apps without too much effort for their specific use case?</p>
-  <a href="#section7" class="internal-link internal-arrow">⬇</a>
+  <a href="#section7" class="internal-link internal-arrow">next</a>
 </section>

--- a/_includes/section7.html
+++ b/_includes/section7.html
@@ -7,5 +7,5 @@
       <p>When all the data is published as linked data, a developer can <strong>easily gather and combine it!</strong></p>
     </div>
   </div>
-  <a href="#section6" class="internal-link internal-arrow">⬇</a>
+  <a href="#section6" class="internal-link internal-arrow">next</a>
 </section>


### PR DESCRIPTION
otherwise they get replaced by emoji on iOS and that's bad because I can't set `color: transparent`
