### PR TITLE
no baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,1 @@
-baseurl: /mobylink
+baseurl: /


### PR DESCRIPTION
new url is vocab.datex.org and not /mobylink
