### PR TITLE
Fix/dont animate if impossible

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,7 @@
     <title>Linked Datex</title>
     <meta name="description" content="">
     <meta name="author" content="">
+    <meta property="og:type" content="website">
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1">
     <link rel="stylesheet" href="{{site.baseurl}}{{layout.style | default: src/css/common.css }}">
     <link rel="shortcut icon" href="{{site.baseurl}}favicon.ico" type="image/x-icon">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,11 +1,11 @@
 ---
 ---
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" prefix="og:http://ogp.me/ns#">
   <head>
     <meta charset="utf-8">
-    <title>Moby Link {% if page.title %} - {% endif %}{{page.title}}</title>
-    <meta name="description" content="{{page.title}} data in Ghent">
+    <title>Linked Datex</title>
+    <meta name="description" content="">
     <meta name="author" content="">
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1">
     <link rel="stylesheet" href="{{site.baseurl}}{{layout.style | default: src/css/common.css }}">

--- a/src/js/parallax.js
+++ b/src/js/parallax.js
@@ -95,6 +95,7 @@ $(function() {
       $('#intro a').css({
         'transform': 'translate(0px,' + wScroll / 2 + '%)'
       });
+    }
 
 
     //   $('#section2 p').css({
@@ -125,16 +126,18 @@ $(function() {
 
     //SECTION3
     if (wScroll > section3Top && wScroll < section3Bottom && !startedSection3) {
-      animateScroll([{
-        '#iconGhent': {
-          transform: ''
-        }
-      }, {
-        '#textGhent, #iconCross': {
-          opacity: '1',
-          transform: ''
-        }
-      }], 500, '#section3');
+      if (animateScroll) {
+        animateScroll([{
+          '#iconGhent': {
+            transform: ''
+          }
+        }, {
+          '#textGhent, #iconCross': {
+            opacity: '1',
+            transform: ''
+          }
+        }], 500, '#section3');
+      }
       startedSection3 = true;
     }
   });


### PR DESCRIPTION
when we're using the arrow buttons, animateScroll is overriden and doesn't exist anymore. This checks for that situation and makes sure that it doesn't f things up
