### PR TITLE
Fix examples

### DIFF
--- a/_examples/accident.md
+++ b/_examples/accident.md
@@ -11,7 +11,7 @@ properties:
     description: A descriptor indicating the most significant factor causing an accident.
   -
     property: vehicleInvolved
-    description: The vehicle involved in the accident.
+    description: The <a href="http://vocab.datex.org/terms#Vehicle">Vehicle</a> involved in the accident.
 ---
 
 This describes an Accident.
@@ -22,7 +22,9 @@ RDFa example:
 <article prefix="dtx: http://vocab.datex.org/terms#" resource="#accident" typeof="dtx:Accident" id="accident">
   <h2 property="dtx:accidentType">collision</h2>
   <p property="dtx:accidentCause">rubberNecking</p>
-  <p property="dtx:vehicleInvolved">Citroen C3</p>
+  <ul property="dtx:vehicleInvolved" resource="#someInvolvedVehicle" typeof="dtx:Vehicle" id="someInvolvedVehicle">
+    <li property="dtx:vehicleModel">Citroën C3</li>
+  </ul>
 </article>
 ```
 
@@ -36,6 +38,9 @@ JSON-LD example:
   "@type": "dtx:Accident",
   "dtx:accidentType": "collision",
   "dtx:accidentCause": "rubberNecking",
-  "dtx:vehicleInvolved": "Citroen C3"
+  "dtx:vehicleInvolved": {
+    "@type": "dtx:Vehicle",
+    "dtx:vehicleModel": "Citroën C3"
+  }
 }
 ```

--- a/_examples/road.md
+++ b/_examples/road.md
@@ -61,6 +61,6 @@ JSON-LD example:
   "dtx:roadSurfaceTemperature": "Road surface temperature",
   "dtx:distanceToThisRoad": 20,
   "dtx:roadDirection": "France",
-  "dtx:typeOfRoad": "meinRoad",
+  "dtx:typeOfRoad": "mainRoad"
 }
 ```


### PR DESCRIPTION
- accident had to have a `Vehicle`
- typos in `road`
